### PR TITLE
Display help page link if present in AppStream metadata (fixes #8)

### DIFF
--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -43,6 +43,9 @@ layout: default
     {% if page.homepage %}
       <a class="button" href="{{page.homepage}}" target="_blank">App Homepage</a>
     {% endif %}
+    {% if page.help_page %}
+      <a class="button" href="{{page.help_page}}" target="_blank">App Help</a>
+    {% endif %}
     <a class="button" href="https://elementary.io/" target="_blank">Get elementary OS</a>
   </div>
 </footer>

--- a/generate-juno.rb
+++ b/generate-juno.rb
@@ -16,6 +16,7 @@ title: ((title))
 summary: ((summary))
 developer: ((dev))
 homepage: ((site))
+help_page: ((help))
 dist: juno
 screenshots:
 ((screenshots))
@@ -50,6 +51,13 @@ YAML.load_stream(componentsData) do |doc|
 		site = "#"
 	end
 	appFile.sub!('((site))', site)
+
+  if not doc['Url'].nil? and not doc['Url']['help'].nil?
+    help = doc['Url']['help']
+  else
+    help = "#"
+  end
+  appFile.sub!('((help))', help)
 
 	unless doc['Custom'].nil?
 		if not doc['Custom']['x-appcenter-color-primary'].nil?

--- a/generate-loki.rb
+++ b/generate-loki.rb
@@ -16,6 +16,7 @@ title: ((title))
 summary: ((summary))
 developer: ((dev))
 homepage: ((site))
+help_page: ((help))
 dist: loki
 screenshots:
 ((screenshots))
@@ -50,6 +51,13 @@ YAML.load_stream(componentsData) do |doc|
 		site = "#"
 	end
 	appFile.sub!('((site))', site)
+
+  if not doc['Url'].nil? and not doc['Url']['help'].nil?
+    help = doc['Url']['help']
+  else
+    help = "#"
+  end
+  appFile.sub!('((help))', help)
 
 	unless doc['Custom'].nil?
 		if not doc['Custom']['x-appcenter-color-primary'].nil?


### PR DESCRIPTION
I updated the Ruby scripts to read `Url.help` from the metadata, and added a conditional link in the footer.

App with help page:
![screenshot from 2018-07-25 01 51 47](https://user-images.githubusercontent.com/8205055/43163987-888869f4-8fad-11e8-9d00-57afee9a26a5.png)

App without one:
![screenshot from 2018-07-25 01 52 48](https://user-images.githubusercontent.com/8205055/43164001-8eb1af16-8fad-11e8-9c6e-04d682fa9772.png)