### PR TITLE
Add Flatpakref downloads for free apps

### DIFF
--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -20,8 +20,11 @@ layout: default
     <h1>{{ page.title }}</h1>
     <p>{{ page.developer }}</p>
 
-    <a class="button suggested" href="https://elementary.io">Get elementary OS</a>
-
+    {% if page.dist == "flatpak" %}
+      {% if page.price == 0 %}
+        <a class="button suggested" href="https://flatpak.elementary.io/repo/appstream/{{ page.app_id }}.flatpakref" download="{{ page.title }}.flatpakref">Download as Flatpak</a>
+      {% endif %}
+    {% endif %}
   </div>
 </header>
 


### PR DESCRIPTION
Partially addresses #62; I intentionally only added to free apps as it feels weird to totally ignore the suggested price and not have a way for people to pay for the download. I'd be curious if we could use Stripe Checkout here to insert that between the app info page and the download for paid apps.