### PR TITLE
Use `baseurl` instead of absolute path

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,13 +14,13 @@ permalink: /404.html
   <p>The app or page you’re looking for isn’t here. You can try browsing for it among the {{apps | size}} curated apps in AppCenter on the homepage, or if you’re on elementary OS, try searching in AppCenter.</p>
   <div class="action">
     <a id="open-appcenter" class="button" href="appstream://">Search AppCenter</a> 
-    <a class="button suggested" href="{{ site.baseurl }}">Visit Homepage</a>
+    <a class="button suggested" href="{{ site.baseurl }}/">Visit Homepage</a>
   </div>
 </div>
 
 <footer>
   <div class="constrain">
-    <a class="button go-home" href="{{ site.baseurl }}">All Apps</a>
+    <a class="button go-home" href="{{ site.baseurl }}/">All Apps</a>
     <a class="button" href="https://developer.elementary.io" target="_blank">Publish on AppCenter</a>
     <a class="button" href="https://elementary.io/" target="_blank">Get elementary OS</a>
   </div>

--- a/404.html
+++ b/404.html
@@ -14,13 +14,13 @@ permalink: /404.html
   <p>The app or page you’re looking for isn’t here. You can try browsing for it among the {{apps | size}} curated apps in AppCenter on the homepage, or if you’re on elementary OS, try searching in AppCenter.</p>
   <div class="action">
     <a id="open-appcenter" class="button" href="appstream://">Search AppCenter</a> 
-    <a class="button suggested" href="/">Visit Homepage</a>
+    <a class="button suggested" href="{{ site.baseurl }}">Visit Homepage</a>
   </div>
 </div>
 
 <footer>
   <div class="constrain">
-    <a class="button go-home" href="/">All Apps</a>
+    <a class="button go-home" href="{{ site.baseurl }}">All Apps</a>
     <a class="button" href="https://developer.elementary.io" target="_blank">Publish on AppCenter</a>
     <a class="button" href="https://elementary.io/" target="_blank">Get elementary OS</a>
   </div>

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -68,7 +68,7 @@ layout: default
 
 <footer>
   <div class="constrain">
-    <a class="button go-home" href="/">← All Apps</a>
+    <a class="button go-home" href="{{ site.baseurl }}">← All Apps</a>
     {% if page.homepage %}
       <a class="button" href="{{ page.homepage }}" target="_blank">Homepage</a>
     {% endif %}

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -68,7 +68,7 @@ layout: default
 
 <footer>
   <div class="constrain">
-    <a class="button go-home" href="{{ site.baseurl }}">← All Apps</a>
+    <a class="button go-home" href="{{ site.baseurl }}/">← All Apps</a>
     {% if page.homepage %}
       <a class="button" href="{{ page.homepage }}" target="_blank">Homepage</a>
     {% endif %}


### PR DESCRIPTION
I found this issue when hosting somewhere other than the root of the domain.

https://github.com/endlessm/eos-apps-web/commit/1ced49f14cc7a0e350cc91c9b9f792a37a683cd5
https://github.com/endlessm/eos-apps-web/commit/1f7bca501a6608c51d799d9cb8f2c06d05cfe573

Instead of using an absolute path, use Jekyll's `site.baseurl` which will be `/` when hosting at the root, or e.g. `/arbitrary/path/` when not.