### PR TITLE
generator: Support new non-deprecated developer tag in appstream

### DIFF
--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -52,7 +52,10 @@ componentsData.css("components component").each do | component |
   summary = component.at_css('summary')
   appFile.sub!('((summary))', CGI.escapeHTML(summary.content))
 
-  dev_name = component.at_css('developer_name')
+  new_dev_tag = component.at_css('developer > name')
+  deprecated_dev_tag = component.at_css('developer_name')
+  dev_name = new_dev_tag.nil? ? deprecated_dev_tag : new_dev_tag
+
   if not dev_name.nil?
     developer = CGI.escapeHTML(dev_name.content)
   else


### PR DESCRIPTION
See https://github.com/elementary/docs/issues/203

I've tested this locally with both the new and old tag format and it's working correctly.