### PR TITLE
Fix generation of app files

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Build
         run: |
+          rm _apps/*
           ruby ./generate-flatpak.rb
 
       - name: Commit

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ bundle install
 
 ### Updating Apps
 
-The list of apps is generated with a simple Ruby script. To rebuild the app list, run:
+The list of apps is generated with a simple Ruby script. To rebuild the app list, delete the existing files so any removals (e.g. end-of-life apps) are reflected, then run the script:
 
 ```shell
+rm _apps/*
 ruby generate-flatpak.rb
 ```
 

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -5,17 +5,10 @@ layout: default
 <header>
   <div class="constrain">
     <img class="icon" width="64" height="64"
-      {% for icon in page.icons %}
-        {% if icon[0] == "64@2" %}
-          srcset="{{ icon[1] }} 2x"
-        {% elsif icon[0] == "128" %}
-          srcset="{{ icon[1] }}"
-        {% elsif icon[0] == "64" %}
-          srcset="{{ icon[1] }}"
-        {% endif %}
-      {% endfor %}
-      src="https://cdn.rawgit.com/elementary/icons/c048cf1bdf9d7735638c1cfe1eea64831e46c83f/apps/64/application-default-icon.svg"
-    alt="{{ page.title }} icon" />
+      srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ page.app_id }}.png"
+      src="https://raw.githubusercontent.com/elementary/icons/main/apps/64/application-default-icon.svg"
+      alt="{{ page.title }} icon"
+    />
 
     <h1>{{ page.title }}</h1>
     <p>{{ page.developer }}</p>

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -32,9 +32,9 @@ redirect_from: ((redirect))
 ((description))'
 
 componentsData.css("components component").each do |component|
-  next unless (component.get_attribute("type") == "desktop" || component.get_attribute("type") == "desktop-application")
+  next if !component.get_attribute("type").match (/^desktop(-application)?$/)
 
-component.xpath('name[@xml:lang]').each do |name|
+  component.xpath('name[@xml:lang]').each do |name|
     name.remove
   end
 

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -54,6 +54,10 @@ componentsData.css("components component").each do |component|
     caption.remove
   end
 
+  component.xpath('//developer/name[@xml:lang]').each do |developer|
+    developer.remove
+  end
+
   puts "\nGenerating #{component.at_css('name').content}"
 
   appFile = template.dup

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -5,11 +5,6 @@ require 'open-uri'
 require 'nokogiri'
 require 'cgi'
 
-###########
-# FLATPAK #
-###########
-
-# HTTPS doesn't work
 componentsDataGz = URI.open('https://flatpak.elementary.io/repo/appstream/x86_64/appstream.xml.gz')
 xmlData = Zlib::GzipReader.new( componentsDataGz ).read
 componentsData = Nokogiri::XML(xmlData)

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -20,8 +20,6 @@ bugtracker: ((bugtracker))
 dist: flatpak
 screenshots:
 ((screenshots))
-icons:
-((icons))
 color:
   primary: "((color_primary))"
   primary-text: "((color_text))"
@@ -36,7 +34,7 @@ redirect_from: ((redirect))
 componentsData.css("components component").each do |component|
   next unless (component.get_attribute("type") == "desktop" || component.get_attribute("type") == "desktop-application")
 
-  component.xpath('name[@xml:lang]').each do |name|
+component.xpath('name[@xml:lang]').each do |name|
     name.remove
   end
 
@@ -46,6 +44,14 @@ componentsData.css("components component").each do |component|
 
   component.xpath('description[@xml:lang]').each do |description|
     description.remove
+  end
+
+  component.xpath('keyword[@xml:lang]').each do |keyword|
+    keyword.remove
+  end
+
+  component.xpath('caption[@xml:lang]').each do |caption|
+    caption.remove
   end
 
   puts "\nGenerating #{component.at_css('name').content}"
@@ -124,32 +130,9 @@ componentsData.css("components component").each do |component|
   image = component.at_css('image')
   if not image.nil?
     screenshots += '  - ' + image.content + "\n"
-
   end
   # TODO: multiple screenshots
-  # releaseHash = ""
-  # unless doc['Screenshots'].nil?
-  #   doc['Screenshots'].each do |screenshot|
-  #     screenshots += "  - " + URI::encode("#{mediaBase}/#{screenshot['source-image']['url']}") + "\n"
-  #     releaseHash = screenshot['source-image']['url'].split("/")[0..3].join("/") if releaseHash.empty?
-  #   end
-  # end
   appFile.sub!('((screenshots))', screenshots.rstrip)
-
-  icons = ""
-  icon_prefix = "https://flatpak.elementary.io/repo/appstream/x86_64/icons/"
-
-  icon64 = component.at_css('icon[width="64"]')
-  if not icon64.nil?
-    icons += '  "64": ' + icon_prefix + '64x64/' + icon64.content + "\n"
-  end
-
-  icon128 = component.at_css('icon[width="128"]')
-  if not icon128.nil?
-    icons += '  "128": ' + icon_prefix + '128x128/' + icon128.content + "\n"
-  end
-
-  appFile.sub!('((icons))', icons.rstrip)
 
   releases = ""
   # TODO: Releases

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -10,7 +10,7 @@ require 'cgi'
 ###########
 
 # HTTPS doesn't work
-componentsDataGz = URI.open('http://flatpak.elementary.io/repo/appstream/x86_64/appstream.xml.gz')
+componentsDataGz = URI.open('https://flatpak.elementary.io/repo/appstream/x86_64/appstream.xml.gz')
 xmlData = Zlib::GzipReader.new( componentsDataGz ).read
 componentsData = Nokogiri::XML(xmlData)
 

--- a/index.html
+++ b/index.html
@@ -16,18 +16,12 @@ color:
   {% for app in flatpak_apps %}
     {% assign id = app.id | remove: '/' %}
     <a class="app button {{app.dist}}" href="{{site.baseurl}}/{{app.slug}}" title="{{app.summary}}" id="{{id}}" tabindex="0">
-      <img width="64" height="64"
-        {% for icon in app.icons %}
-          {% if icon[0] == "64@2" %}
-            srcset="{{icon[1]}} 2x"
-          {% elsif icon[0] == "128" %}
-            srcset="{{icon[1]}}"
-          {% elsif icon[0] == "64" %}
-            srcset="{{icon[1]}}"
-          {% endif %}
-        {% endfor %}
-        src="https://cdn.rawgit.com/elementary/icons/c048cf1bdf9d7735638c1cfe1eea64831e46c83f/apps/64/application-default-icon.svg"
-      alt="{{app.title}} icon" />
+      <img class="icon" width="64" height="64" loading="lazy"
+        srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/128x128/{{ id }}.png"
+        srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ id }}.png"
+        src="https://raw.githubusercontent.com/elementary/icons/main/apps/64/application-default-icon.svg"
+        alt="{{ app.title }} icon"
+      />
 
       <span class="title">{{ app.title }}</span>
       <span class="summary">{{ app.summary }}</span>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@ color:
     {% assign id = app.id | remove: '/' %}
     <a class="app button {{app.dist}}" href="{{site.baseurl}}/{{app.slug}}" title="{{app.summary}}" id="{{id}}" tabindex="0">
       <img class="icon" width="64" height="64" loading="lazy"
-        srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/128x128/{{ id }}.png"
         srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ id }}.png"
         src="https://raw.githubusercontent.com/elementary/icons/main/apps/64/application-default-icon.svg"
         alt="{{ app.title }} icon"


### PR DESCRIPTION
It looks like removing the legacy files themselves was missed in https://github.com/elementary/appcenter-web/pull/94, and they aren't being removed by CI. This should fix generation of app files (and thus app listing pages); when it runs in CI next, we should see a large amount of outdated files in `_apps/` removed. This includes apps marked as EOL, as they are no longer present in the appstream downloaded from flatpak.elementary.io.

I did not add/commit the changes to the _apps/ files themselves since that will be handled by the hourly CI run, but I can if it makes it easier to review/understand the changes.

- **[generate-flatpak: Apparently HTTPS works, now, so use it](https://github.com/elementary/appcenter-web/commit/d767bdcc906476ab3b94b7a3b7610c6692df8f24)**

  I was getting weird behavior locally when trying to use the HTTP URL as before, so out of curiosity I updated it to HTTPS—and it worked! Maybe something changed with the infrastructure configuration. 🤷🏻

- **[Workflow: delete existing apps before generating new ones](https://github.com/elementary/appcenter-web/commit/4c0e783c5658ad45670b3ba625f119be4f0a8ded)**

   Apparently old app files were sticking around because we weren't deleting them before regenerating them. This updates the workflow to clear the folder out so it's always starting fresh. Updates to existing files should still come through the same way since CI checks a git diff after all operations are complete.

- **[generate-flatpak: Remove outdated comments](https://github.com/elementary/appcenter-web/commit/9db8abd327167b266cc8349f7dd3a305ae55f527)**

  I forgot to remove the comment about HTTPS not working, and then realized since the script has been pared down to only deal with Flatpak, we probably don't need the giant `FLATPAK` comment do denote that section.

- **[README: mention deleting existing files](https://github.com/elementary/appcenter-web/pull/96/commits/1f74b65eb774f7465d83f1e201056c137e70e839)**

  Hopefully makes it more clear what's being done in the CI (and prevents similar issues in the future).

- **[generate-flatpak: allow desktop-application, strip translations](https://github.com/elementary/appcenter-web/pull/96/commits/fc8c572df35572690d2ff90720921bc2df9dd58a)**

  This re-adds newer apps that were generated within the last month, stripping them of the (unused) translated strings so we don't end up accidentally using a translation in place of the default string. Fixes #99.

- **[Fix icons by using app ID](https://github.com/elementary/appcenter-web/pull/96/commits/55f617b9cd2b3c2b6abab4928e8d3ced4ef2f55f)**

  I noticed we were putting the icons into the markdown files, but for Flatpaks, they're predictably at a well-known URL based on the app ID. So, skip all that and use the path directly. I also updated the fallback icon since the old rawgit link was dead.