### PR TITLE
generate-flatpak: Collect apps with the "desktop-application" type

### DIFF
--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -40,7 +40,7 @@ redirect_from: ((redirect))
 
 puts 'about to iterate thru components...'
 componentsData.css("components component").each do | component |
-  next if component.get_attribute("type") != "desktop"
+  next if !component.get_attribute("type").match (/^desktop(-application)?$/)
 
   puts "Generating #{component.at_css('name').content}"
 


### PR DESCRIPTION
Fixes #99

Recent apps often uses `<component type="desktop-application">` instead of [old-fashioned](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#id-1.3.8.3.4) `<component type="desktop">` in the metainfo files. However, our ruby script just collects from the `desktop` apps and `desktop-application` is ignored. This PR make sure collect metainfo from `desktop-application` apps too.
