### PR TITLE
Add support for light and dark brand colors from appstream data

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,7 @@
   <link rel="apple-touch-icon" href="https://elementary.io/images/launcher-icons/apple-touch-icon.png">
   <link rel="icon" type="image/png" href="https://elementary.io/images/favicon.png" sizes="256x256">
 
-  <meta name="theme-color" content="{% if page.color.primary != "((color_primary))" %}{{page.color.primary}}{% else %}{{site.color.primary}}{% endif %}">
+  <meta name="theme-color" content="{% if page.color.primary %}{{page.color.primary}}{% else %}{{site.color.primary}}{% endif %}">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@elementary">

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -7,6 +7,7 @@ layout: default
     <img class="icon" width="64" height="64"
       srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ page.app_id }}.png, https://flatpak.elementary.io/repo/appstream/x86_64/icons/128x128/{{ page.app_id }}.png 2x"
       src="https://raw.githubusercontent.com/elementary/icons/main/apps/64/application-default-icon.svg"
+      onerror="this.srcset=this.src"
       alt="{{ page.title }} icon"
     />
 

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -77,7 +77,15 @@ layout: default
 
 <style>
   header {
-    background-color: {% if page.color.primary != "((color_primary))" %}{{ page.color.primary }}{% else %}{{ site.color.primary }}{% endif %};
-    color: {% if page.color.primary-text != "((color_text))" %}{{ page.color.primary-text }}{% else %}{{ site.color.primary-text }}{% endif %}
+    background-color: {{ page.color.primary }};
+    color: {{ page.color.primary-text }};
   }
+  {% if page.color.primary-dark %}
+    @media (prefers-color-scheme: dark) {
+      header {
+        background-color: {{ page.color.primary-dark }};
+        color: {{ page.color.primary-text-dark }};
+      }
+    }
+  {% endif %}
 </style>

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -5,7 +5,7 @@ layout: default
 <header>
   <div class="constrain">
     <img class="icon" width="64" height="64"
-      srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ page.app_id }}.png"
+      srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ page.app_id }}.png, https://flatpak.elementary.io/repo/appstream/x86_64/icons/128x128/{{ page.app_id }}.png 2x"
       src="https://raw.githubusercontent.com/elementary/icons/main/apps/64/application-default-icon.svg"
       alt="{{ page.title }} icon"
     />

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -159,7 +159,7 @@ componentsData.css("components component").each do |component|
                        component.at_css('color[type="primary"]') ||
                        component.at_css('value[key="x-appcenter-color-primary"]')
 
-  if not custom_color_light.nil? and not custom_color_dark.nil?
+  if custom_color_light&.content&.start_with?('#') && custom_color_dark&.content&.start_with?('#')
     color_primary = custom_color_light.content
     color_primary_dark = custom_color_dark.content
     color_text = optimal_contrast(color_primary)

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -151,8 +151,13 @@ componentsData.css("components component").each do |component|
   color_text = "#333"
   color_text_dark = "#fff"
 
-  custom_color_light = component.at_css('color[type="primary"][scheme_preference="light"]') || component.at_css('color[type="primary"]') || component.at_css('value[key="x-appcenter-color-primary"]')
-  custom_color_dark  = component.at_css('color[type="primary"][scheme_preference="dark"]')  || component.at_css('color[type="primary"]') || component.at_css('value[key="x-appcenter-color-primary"]')
+  custom_color_light = component.at_css('color[type="primary"][scheme_preference="light"]') ||
+                       component.at_css('color[type="primary"]') ||
+                       component.at_css('value[key="x-appcenter-color-primary"]')
+
+  custom_color_dark  = component.at_css('color[type="primary"][scheme_preference="dark"]') ||
+                       component.at_css('color[type="primary"]') ||
+                       component.at_css('value[key="x-appcenter-color-primary"]')
 
   if not custom_color_light.nil? and not custom_color_dark.nil?
     color_primary = custom_color_light.content

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -64,7 +64,9 @@ def optimal_contrast(bg_hex)
   white = '#fff'
   contrast_black = contrast_ratio(bg_hex, black)
   contrast_white = contrast_ratio(bg_hex, white)
-  contrast_black > contrast_white ? black : white
+  # NOTE: We cheat and add 3 to contrast when checking against black,
+  # because white generally looks better on a colored background
+  contrast_black > contrast_white + 3 ? black : white
 end
 
 componentsData.css("components component").each do |component|

--- a/generate-flatpak.rb
+++ b/generate-flatpak.rb
@@ -23,6 +23,8 @@ screenshots:
 color:
   primary: "((color_primary))"
   primary-text: "((color_text))"
+  primary-dark: "((color_primary_dark))"
+  primary-text-dark: "((color_text_dark))"
 price: ((price))
 releases:
 ((releases))
@@ -30,6 +32,40 @@ redirect_from: ((redirect))
 ---
 
 ((description))'
+
+# Convert hex to RGB
+def hex_to_rgb(hex)
+  hex = hex.delete('#')
+  hex = hex.chars.map { |c| c * 2 }.join if hex.length == 3
+  [hex[0..1], hex[2..3], hex[4..5]].map { |c| c.to_i(16) }
+end
+
+# Relative luminance for RGB per WCAG
+def luminance(hex)
+  r, g, b = hex_to_rgb(hex).map do |channel|
+    c = channel / 255.0
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055)**2.4
+  end
+  0.2126 * r + 0.7152 * g + 0.0722 * b
+end
+
+# Contrast ratio between two colors
+def contrast_ratio(hex1, hex2)
+  l1 = luminance(hex1)
+  l2 = luminance(hex2)
+  lighter = [l1, l2].max
+  darker = [l1, l2].min
+  (lighter + 0.05) / (darker + 0.05)
+end
+
+# Choose text color (black or white) with higher contrast
+def optimal_contrast(bg_hex)
+  black = '#000'
+  white = '#fff'
+  contrast_black = contrast_ratio(bg_hex, black)
+  contrast_white = contrast_ratio(bg_hex, white)
+  contrast_black > contrast_white ? black : white
+end
 
 componentsData.css("components component").each do |component|
   next if !component.get_attribute("type").match (/^desktop(-application)?$/)
@@ -108,15 +144,19 @@ componentsData.css("components component").each do |component|
   end
   appFile.sub!('((bugtracker))', bugtracker)
 
-  color_primary = "#485a6c"
-  color_text = "#fff"
+  color_primary = "#d1e6f9"
+  color_primary_dark = "#485a6c"
+  color_text = "#333"
+  color_text_dark = "#fff"
 
-  custom_color = component.at_css('value[key="x-appcenter-color-primary"]')
-  custom_text = component.at_css('value[key="x-appcenter-color-primary-text"]')
+  custom_color_light = component.at_css('color[type="primary"][scheme_preference="light"]') || component.at_css('color[type="primary"]') || component.at_css('value[key="x-appcenter-color-primary"]')
+  custom_color_dark  = component.at_css('color[type="primary"][scheme_preference="dark"]')  || component.at_css('color[type="primary"]') || component.at_css('value[key="x-appcenter-color-primary"]')
 
-  if not custom_color.nil? and not custom_text.nil?
-    color_primary = custom_color.content
-    color_text = custom_text.content
+  if not custom_color_light.nil? and not custom_color_dark.nil?
+    color_primary = custom_color_light.content
+    color_primary_dark = custom_color_dark.content
+    color_text = optimal_contrast(color_primary)
+    color_text_dark = optimal_contrast(color_primary_dark)
   end
 
   price = "false"
@@ -127,7 +167,9 @@ componentsData.css("components component").each do |component|
   end
 
   appFile.sub!('((color_primary))', color_primary)
+  appFile.sub!('((color_primary_dark))', color_primary_dark)
   appFile.sub!('((color_text))', color_text)
+  appFile.sub!('((color_text_dark))', color_text_dark)
   appFile.sub!('((price))', price)
 
   screenshots = ''

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ color:
     {% assign id = app.id | remove: '/' %}
     <a class="app button {{app.dist}}" href="{{site.baseurl}}/{{app.slug}}" title="{{app.summary}}" id="{{id}}" tabindex="0">
       <img class="icon" width="64" height="64" loading="lazy"
-        srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ id }}.png"
+        srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ id }}.png, https://flatpak.elementary.io/repo/appstream/x86_64/icons/128x128/{{ id }}.png 2x"
         src="https://raw.githubusercontent.com/elementary/icons/main/apps/64/application-default-icon.svg"
         alt="{{ app.title }} icon"
       />

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@ color:
       <img class="icon" width="64" height="64" loading="lazy"
         srcset="https://flatpak.elementary.io/repo/appstream/x86_64/icons/64x64/{{ id }}.png, https://flatpak.elementary.io/repo/appstream/x86_64/icons/128x128/{{ id }}.png 2x"
         src="https://raw.githubusercontent.com/elementary/icons/main/apps/64/application-default-icon.svg"
+        onerror="this.srcset=this.src"
         alt="{{ app.title }} icon"
       />
 

--- a/index.html
+++ b/index.html
@@ -28,9 +28,17 @@ color:
 
     <style>
       .app[id="{{id}}"]:hover,.app[id="{{id}}"]:focus {
-        background-color: {% if app.color.primary != "((color_primary))" %}{{app.color.primary}}{% else %}{{site.color.primary}}{% endif %};
-        color: {% if app.color.primary-text != "((color_text))" %}{{app.color.primary-text}}{% else %}{{site.color.primary-text}}{% endif %};
+        background-color: {{app.color.primary}};
+        color: {{app.color.primary-text}};
       }
+      {% if app.color.primary-dark %}
+        @media (prefers-color-scheme: dark) {
+          .app[id="{{id}}"]:hover,.app[id="{{id}}"]:focus {
+            background-color: {{app.color.primary-dark}};
+            color: {{app.color.primary-text-dark}};
+          }
+        }
+      {% endif %}
     </style>
   {% endfor %}
 </div>


### PR DESCRIPTION
Currently appcenter-web still uses the legacy custom `x-appcenter-color-primary` and `x-appcenter-color-primary-text` tags.

This pull requests add support for extracting and using the [mainstream branding color tags](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-branding) including light and dark scheme.

The foreground text color is either white or black depending on which one provides the most contrast to the branding background color (same as in AppCenter itself).

Apps without any branding now have a light blue background in light mode (same as in AppCenter itself).

Other changes:
- Removed needless checks for `page.color.primary != "((color_primary))"` because there is always an actual (fallback) color present.
- Added 128x128 icon src for use on HiDPI displays to fix all icons being blurry. I am aware that reduces stroke width but there are simply [no 64x64@2 images available](https://flatpak.elementary.io/repo/appstream/x86_64/icons/) otherwise i would have used that.
- Now using `application-default-icon` actually as fallback when there is an error loading the app icon.

> [!IMPORTANT]
> **For clarity only code changes are included in this pull request!**
> To update the apps listing its necessary to run: 
> `ruby generate-flatpak.rb`

## Preview

### No branding

**[Agenda](https://appcenter.elementary.io/com.github.dahenson.agenda/)**

Before (light and dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/eb5dc0be-c7ec-4c77-9f3e-d121cc3f4d00" />

After (light)
<img width="820" height="95" src="https://github.com/user-attachments/assets/5d1b3033-ac5f-4aa1-9c25-860e5d097c29" />

After (dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/40b25846-44be-47be-996b-00ced143d26c" />

### Branding colors

**[Music](https://appcenter.elementary.io/io.elementary.music/)**

Before (light and dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/1cffe9ef-3b3d-4363-b5be-b583f43669a9" />

After (light)
<img width="820" height="95" src="https://github.com/user-attachments/assets/8dad8a86-a0af-437b-a5d0-a494466cb60b" />

After (dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/63506596-5f95-446f-b529-4953f778da07" />

**[Haguichi](https://appcenter.elementary.io/com.github.ztefn.haguichi/)**

Before (light and dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/4be8a116-087d-414d-9111-d27b7ba8a040" />

After (light)
<img width="820" height="95" src="https://github.com/user-attachments/assets/0f46e28d-f196-447b-89fe-f7c4bc2997f3" />

After (dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/de46da7b-7443-46df-a8fb-a5c9a018ca1c" />


### Legacy colors

**[QRit](https://appcenter.elementary.io/com.github.sergius02.qrit/)**

Before (light and dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/9fb3dbc6-cc44-41b4-9d21-3df91969e4f1" />

After (light and dark)
<img width="820" height="95" src="https://github.com/user-attachments/assets/bf96e18e-5eed-4312-839b-675d911f4d53" />
